### PR TITLE
Add class to force page images

### DIFF
--- a/includes/Hooks/ParserFileProcessingHookHandlers.php
+++ b/includes/Hooks/ParserFileProcessingHookHandlers.php
@@ -335,6 +335,12 @@ class ParserFileProcessingHookHandlers implements
 			$score += 5;
 		}
 
+		// MCW change: add class to force page images
+		if ( in_array( 'forcepageimage', $classes ) ) {
+			// Only choose between images with class=forcepageimage
+			$score += 1000;
+		}
+
 		$denylist = $this->getDenylist();
 		if ( isset( $denylist[$image->getFileName()] ) ) {
 			$score = -1000;


### PR DESCRIPTION
Add `forcepageimage` class to limit the selection of the page image to only images with that class.

Solves ticket ID 2271